### PR TITLE
Changed griffincamp to la commune in footer

### DIFF
--- a/src/_data/faq.json
+++ b/src/_data/faq.json
@@ -19,7 +19,7 @@
     {
       "question": "If I have questions after class time, is someone able to help me?",
       "answer": "Yes, our instructors have office hours where they will happily assist you with any question or technical problem you may have encountered."
-    }
+    },
     {
       "question": "How much does the training cost?",
       "answer": "Tuition for the training is $1,495 and is payable before the start of the training."

--- a/src/_data/faq.json
+++ b/src/_data/faq.json
@@ -19,7 +19,7 @@
     {
       "question": "If I have questions after class time, is someone able to help me?",
       "answer": "Yes, our instructors have office hours where they will happily assist you with any question or technical problem you may have encountered."
-    },
+    }
     {
       "question": "How much does the training cost?",
       "answer": "Tuition for the training is $1,495 and is payable before the start of the training."
@@ -34,7 +34,7 @@
     },
     {
       "question": "Where is the course taught?",
-      "answer": "These courses are currently taught at the GriffinCamp (1384 Rue Notre-Dame West, Montréal, QC H3C 1K8) in the heart of Montreal's innovation district."
+      "answer": "These courses are currently taught at La Commune (440 Place Jacques Cartier, 4th floor, H2Y 2B3)."
     }
   ]
 }

--- a/src/_data/fulltime_faq.json
+++ b/src/_data/fulltime_faq.json
@@ -46,7 +46,7 @@
     },
     {
       "question": "Where is the course taught?",
-      "answer": "These courses are currently taught at the GriffinCamp (1384 Rue Notre-Dame West, Montréal, QC H3C 1K8) in the heart of Montreal's innovation district."
+      "answer": "These courses are currently taught at La Commune (440 Place Jacques Cartier, 4th floor, H2Y 2B3)."
     }
   ]
 }

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -69,7 +69,7 @@
       <div class="main-footer__twitter"><a href="https://twitter.com/decodemtl" target="_blank"><i class="fa fa-twitter-square fa-2x"></i></a></div>
       <div class="main-footer__email"><a href="mailto:hello@decodemtl.com"><i class="fa fa-envelope-o fa-2x"></i></a></div>
   </div>
-  <div class="main-footer__contact">You can find us at the <a href="http://griffincamp.com/" target="_blank">GriffinCamp</a>,  reach us by
+  <div class="main-footer__contact">You can find us at the <a href="http://www.lacommune.ca/" target="_blank">La Commune</a>,  reach us by
       <a href="mailto:hello@decodemtl.com">email</a>,  or by phone at <a href="tel:+14387887057">438.788.7057</a></div>
     <div class="main-footer__legal">
         <div class="main-footer__copyright">&copy; 2015 9320-7223 Québec inc.</div>

--- a/src/about/index.html
+++ b/src/about/index.html
@@ -13,7 +13,7 @@ description: DecodeMTL is a coding bootcamp in Montreal, Quebec. We offer full-t
   <div class="section-content">
     <h1 class="about-page__heading">About DecodeMTL</h1>
     <p class="about-page__text">
-      We are currently running our courses out of the GriffinCamp a leading startup accelerator in downtown Montreal's innovation district.
+      We are currently running our courses out of "La Commune" a leading startup accelerator in downtown Montreal's innovation district.
       Our goal is to bring coding literacy to as many people as possible. We believe that with the right environment, best teachers,
       and partnerships with the right companies, we can fuel local, national, and international organizations with a new
       wave of talented developers.

--- a/src/about/index.html
+++ b/src/about/index.html
@@ -13,7 +13,7 @@ description: DecodeMTL is a coding bootcamp in Montreal, Quebec. We offer full-t
   <div class="section-content">
     <h1 class="about-page__heading">About DecodeMTL</h1>
     <p class="about-page__text">
-      We are currently running our courses out of "La Commune" a leading startup accelerator in downtown Montreal's innovation district.
+      We are currently running our courses out of "La Commune" - a startup space in Montreal's old port.
       Our goal is to bring coding literacy to as many people as possible. We believe that with the right environment, best teachers,
       and partnerships with the right companies, we can fuel local, national, and international organizations with a new
       wave of talented developers.


### PR DESCRIPTION
Hi Ziad,

I found two instances of GriffinCamp and changed them both to "La Commune".
I also changed the `<a href=...` to www.lacommune.ca
