### PR TITLE
Changes to reflect new location on the website (Name & Address of location of bootcamp)

### DIFF
--- a/src/_data/faq.json
+++ b/src/_data/faq.json
@@ -34,7 +34,7 @@
     },
     {
       "question": "Where is the course taught?",
-      "answer": "These courses are currently taught at the GriffinCamp (1384 Rue Notre-Dame West, Montréal, QC H3C 1K8) in the heart of Montreal's innovation district."
+      "answer": "These courses are currently taught at the LaCommune (440 Place Jacques-Cartier, H2Y 3B3 Montréal ) in the heart of Montreal's innovation district."
     }
   ]
 }

--- a/src/_data/faq.json
+++ b/src/_data/faq.json
@@ -34,7 +34,7 @@
     },
     {
       "question": "Where is the course taught?",
-      "answer": "These courses are currently taught at the LaCommune (440 Place Jacques-Cartier, H2Y 3B3 Montréal ) in the heart of Montreal's innovation district."
+      "answer": "These courses are currently taught at the La Commune (440 Place Jacques-Cartier, H2Y 3B3 Montréal ) in the heart of Montreal's innovation district."
     }
   ]
 }

--- a/src/_data/fulltime_faq.json
+++ b/src/_data/fulltime_faq.json
@@ -46,7 +46,7 @@
     },
     {
       "question": "Where is the course taught?",
-      "answer": "These courses are currently taught at the LaCommune (440 Place Jacques-Cartier, H2Y 3B3 Montréal) in the heart of Montreal's innovation district."
+      "answer": "These courses are currently taught at the La Commune (440 Place Jacques-Cartier, H2Y 3B3 Montréal) in the heart of Montreal's innovation district."
     }
   ]
 }

--- a/src/_data/fulltime_faq.json
+++ b/src/_data/fulltime_faq.json
@@ -46,7 +46,7 @@
     },
     {
       "question": "Where is the course taught?",
-      "answer": "These courses are currently taught at the GriffinCamp (1384 Rue Notre-Dame West, Montréal, QC H3C 1K8) in the heart of Montreal's innovation district."
+      "answer": "These courses are currently taught at the LaCommune (440 Place Jacques-Cartier, H2Y 3B3 Montréal) in the heart of Montreal's innovation district."
     }
   ]
 }

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -69,7 +69,7 @@
       <div class="main-footer__twitter"><a href="https://twitter.com/decodemtl" target="_blank"><i class="fa fa-twitter-square fa-2x"></i></a></div>
       <div class="main-footer__email"><a href="mailto:hello@decodemtl.com"><i class="fa fa-envelope-o fa-2x"></i></a></div>
   </div>
-  <div class="main-footer__contact">You can find us at the <a href="http://griffincamp.com/" target="_blank">GriffinCamp</a>,  reach us by
+  <div class="main-footer__contact">You can find us at the <a href="http://griffincamp.com/" target="_blank">La Commune</a>,  reach us by
       <a href="mailto:hello@decodemtl.com">email</a>,  or by phone at <a href="tel:+14387887057">438.788.7057</a></div>
     <div class="main-footer__legal">
         <div class="main-footer__copyright">&copy; 2015 9320-7223 Québec inc.</div>

--- a/src/_layouts/default.html
+++ b/src/_layouts/default.html
@@ -69,7 +69,7 @@
       <div class="main-footer__twitter"><a href="https://twitter.com/decodemtl" target="_blank"><i class="fa fa-twitter-square fa-2x"></i></a></div>
       <div class="main-footer__email"><a href="mailto:hello@decodemtl.com"><i class="fa fa-envelope-o fa-2x"></i></a></div>
   </div>
-  <div class="main-footer__contact">You can find us at the <a href="http://griffincamp.com/" target="_blank">La Commune</a>,  reach us by
+  <div class="main-footer__contact">You can find us at the <a href="http://www.lacommune.ca/" target="_blank">La Commune</a>,  reach us by
       <a href="mailto:hello@decodemtl.com">email</a>,  or by phone at <a href="tel:+14387887057">438.788.7057</a></div>
     <div class="main-footer__legal">
         <div class="main-footer__copyright">&copy; 2015 9320-7223 Québec inc.</div>

--- a/src/about/index.html
+++ b/src/about/index.html
@@ -13,7 +13,7 @@ description: DecodeMTL is a coding bootcamp in Montreal, Quebec. We offer full-t
   <div class="section-content">
     <h1 class="about-page__heading">About DecodeMTL</h1>
     <p class="about-page__text">
-      We are currently running our courses out of the LaCommune a leading startup accelerator in downtown Montreal's innovation district.
+      We are currently running our courses out of the LaCommune a coworking space in Old Port Montreal.
       Our goal is to bring coding literacy to as many people as possible. We believe that with the right environment, best teachers,
       and partnerships with the right companies, we can fuel local, national, and international organizations with a new
       wave of talented developers.

--- a/src/about/index.html
+++ b/src/about/index.html
@@ -13,7 +13,7 @@ description: DecodeMTL is a coding bootcamp in Montreal, Quebec. We offer full-t
   <div class="section-content">
     <h1 class="about-page__heading">About DecodeMTL</h1>
     <p class="about-page__text">
-      We are currently running our courses out of the LaCommune a coworking space in Old Port Montreal.
+      We are currently running our courses out of the LaCommune, a coworking space in Old Port Montreal.
       Our goal is to bring coding literacy to as many people as possible. We believe that with the right environment, best teachers,
       and partnerships with the right companies, we can fuel local, national, and international organizations with a new
       wave of talented developers.

--- a/src/about/index.html
+++ b/src/about/index.html
@@ -13,7 +13,7 @@ description: DecodeMTL is a coding bootcamp in Montreal, Quebec. We offer full-t
   <div class="section-content">
     <h1 class="about-page__heading">About DecodeMTL</h1>
     <p class="about-page__text">
-      We are currently running our courses out of the LaCommune, a coworking space in Old Port Montreal.
+      We are currently running our courses out of La Commune, a coworking space in Old Port Montreal.
       Our goal is to bring coding literacy to as many people as possible. We believe that with the right environment, best teachers,
       and partnerships with the right companies, we can fuel local, national, and international organizations with a new
       wave of talented developers.

--- a/src/about/index.html
+++ b/src/about/index.html
@@ -13,7 +13,7 @@ description: DecodeMTL is a coding bootcamp in Montreal, Quebec. We offer full-t
   <div class="section-content">
     <h1 class="about-page__heading">About DecodeMTL</h1>
     <p class="about-page__text">
-      We are currently running our courses out of the GriffinCamp a leading startup accelerator in downtown Montreal's innovation district.
+      We are currently running our courses out of the LaCommune a leading startup accelerator in downtown Montreal's innovation district.
       Our goal is to bring coding literacy to as many people as possible. We believe that with the right environment, best teachers,
       and partnerships with the right companies, we can fuel local, national, and international organizations with a new
       wave of talented developers.


### PR DESCRIPTION
The previous location (Griffin Camp) is no longer where we work. Hence, I have changed the footer name to "La Commune"
