### PR TITLE
Some more changes to the DecodeMTL website

### DIFF
--- a/src/assets/scss/_intro-section.scss
+++ b/src/assets/scss/_intro-section.scss
@@ -16,6 +16,7 @@
 
     & .intro-section__headline {
       line-height: 1.4;
+      font-family: cursive;
     }
   }
   

--- a/src/assets/scss/_main-footer.scss
+++ b/src/assets/scss/_main-footer.scss
@@ -8,6 +8,8 @@
     font-weight: 100;
     font-size: 1.5em;
     margin: 0 0 1.2em;
+    font-family: sans-serif;
+    font-size: 40px;
   }
 
   &__subscribe-form {

--- a/src/assets/scss/_upcoming-courses.scss
+++ b/src/assets/scss/_upcoming-courses.scss
@@ -38,3 +38,7 @@
     }
   }
 }
+
+#full {
+  color:darkred;
+}

--- a/src/assets/scss/_upcoming-courses.scss
+++ b/src/assets/scss/_upcoming-courses.scss
@@ -30,6 +30,7 @@
     display: inline-block;
     padding: 16px;
     color: #000;
+    border-radius:50%;
     @include transition(background-color 300ms ease-in, color 300ms ease-in);
 
     &:hover {

--- a/src/web-development-full-time/index.html
+++ b/src/web-development-full-time/index.html
@@ -181,7 +181,7 @@ description: Intensive, full-time web development course in Montreal. Go from be
         <p class="upcoming-courses__info">TA's on hand: Monday to Friday from
         <nobr>6pm - 9pm</nobr>
         </p>
-        <p class="upcoming-courses__info"><strong>Sorry, this course is full.</strong></p>
+        <p class="upcoming-courses__info" id="full"><strong>Sorry, this course is full.</strong></p>
       </li>
     </ul>
   </div>


### PR DESCRIPTION
Hi Ziad,
I made some more changes to the website that you might be interested to see:
- Changed 'Newsletter' `font-family` in footer to `sans-serif` and `font-size` to `40px`
- On the Web development full-time page, set `color` of 'Course is full' notice to `darkred`
- On that same page: set `border-radius` of Apply button to `50%`
- Set `font-family` to `cursive` in the intro-section file because cursive is pretty.

Cheers,
C.
