### PR TITLE
changes to landing page (pantone colours)

### DIFF
--- a/src/assets/scss/app.scss
+++ b/src/assets/scss/app.scss
@@ -23,3 +23,28 @@
 @import "about-page";
 @import "curriculum";
 @import "on-demand";
+
+/* Text of "Learn to Code" to #92A8D1
+<h1 class="intro-section__headline">Learn to Code</h1>*/
+.intro-section {
+    color: #92A8D1;
+}
+
+
+/* <a class="intro-section__link" href="/web-development-full-time" style="
+    color: #92A8D1;
+">Full-Time</a>*/
+element.style {
+    color: #92A8D1;
+}
+
+/*<a class="intro-section__link" href="/web-development-part-time">Part-Time</a>*/
+.intro-section__link {
+    color: rgb(247, 202, 201);
+}
+
+/*changes to <body>*/
+body {
+    background: #F7CAC9;
+    color: #92A8D1;
+}


### PR DESCRIPTION
Some css to fancy up the DecodeMTL landing page with this year's Pantone colours of the year!

(Note: Must add HTML inline style to link <a> for "Full Time" because the "Full Time" & "Part Time" links share the same class style and we want to force different colours.)

![pantone-landing-page](https://cloud.githubusercontent.com/assets/16546784/12595266/5bd8c9cc-c448-11e5-8da4-dc7d13f6f23f.JPG)
