### PR TITLE
Changed the name of the Head instructor in the About and Full Time course pages

### DIFF
--- a/src/about/index.html
+++ b/src/about/index.html
@@ -30,10 +30,10 @@ description: DecodeMTL is a coding bootcamp in Montreal, Quebec. We offer full-t
     </p>
     <ul class="meet-the-team__members">
       <li class="meet-the-team__member">
-        <img class="meet-the-team__member-pic" src="https://www.gravatar.com/avatar/9668b6478fb28dea732204066a69a1db.jpg?s=300" alt="Ziad Saab">
-        <h2 class="meet-the-team__member-name">Ziad Saab</h2>
+        <img class="meet-the-team__member-pic" src="https://media.licdn.com/media/p/3/005/07d/284/2a3e53f.jpg" alt="Pau Cortes">
+        <h2 class="meet-the-team__member-name">Pau Cort&eacute;s</h2>
         <p class="meet-the-team__member-hello">
-          Co Founder &amp; CTO
+          Head instructor
         </p>
       </li>
       <li class="meet-the-team__member">

--- a/src/web-development-full-time/index.html
+++ b/src/web-development-full-time/index.html
@@ -120,22 +120,20 @@ description: Intensive, full-time web development course in Montreal. Go from be
   <div class="section-content">
     <h1 class="instructor__heading">Meet your instructor</h1>
     <article class="instructor-bio">
-      <img class="instructor-bio__pic" src="https://www.gravatar.com/avatar/9668b6478fb28dea732204066a69a1db.jpg?s=300" alt="Ziad Saab">
+      <img class="instructor-bio__pic" src="https://https://media.licdn.com/media/p/3/005/07d/284/2a3e53f.jpg" alt="Pau Cortes">
 
       <div class="instructor-bio__text">
-        <h1 class="instructor-bio__name">Ziad Saab</h1>
+        <h1 class="instructor-bio__name">Pau Cort&eacute;s</h1>
 
         <p class="instructor-bio__title">
-        <nobr>Head of Education</nobr>
-        /
-        <nobr>Co-Founder</nobr>
+        <nobr>Head instructor</nobr>
+        
         at DecodeMTL
         </p>
         <p class="instructor-bio__text">
-          Ziad is a full-stack web developer and educator from Montreal, Canada with over ten years of experience.
-          He's worked for startups, agencies, and large companies. He is also an instructor at the local Ladies
-          Learning Code chapter and a co-founder at DecodeMTL. Ziad loves teaching more than anything and is motivated
-          by seeing his students succeed.
+          Pau is a beginner full-stack web developer from Spain (Europe, <strong><em>NOT</em></strong> South America) with no coding experience whatsoever.
+          His work experience is colorful to say the least, yet somehow he's made it to Head instructor not having even finished his first coding course, now that's quite an achievement!!
+          But worry not, even though he might not know much about coding, he will be very happy to pass this knowledge on to you.
         </p>
       </div>
     </article>


### PR DESCRIPTION
Hello,

I have updated the About and the Full Time course pages in order to reflect the recent replacement of the Head instructor in DecodeMTL.

Thanks!
